### PR TITLE
Make import of pip internals work with pip 10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,13 @@ import uuid
 import codecs
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-from pip.req import parse_requirements
+
+
+# From https://discuss.frappe.io/t/pip-major-change-on-version-10/724
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 
 class Tox(TestCommand):


### PR DESCRIPTION
The `parse_requirements` function lives in a
different place in pip versions 10 and later.

Apparently it isn't a good idea to use these
internal pip functions, but for now this work-
around sidesteps the issue.

Fix code is from
https://discuss.frappe.io/t/pip-major-change-on-version-10/724